### PR TITLE
Bugfix/issue #540

### DIFF
--- a/src/core/models/scorecardIndicator.js
+++ b/src/core/models/scorecardIndicator.js
@@ -15,7 +15,7 @@ export default class ScorecardIndicator extends DataModel {
       showColors: true,
       legends: [],
       specificTargets: [],
-      specificTargetSet: false
+      specificTargetsSet: false
     };
   }
 }

--- a/src/core/state/scorecard.js
+++ b/src/core/state/scorecard.js
@@ -58,7 +58,7 @@ const defaultValue = {
             name: i18n.t("Not on track"),
         },
     ],
-    scorecardOptions: new ScorecardOptions(),
+    options: new ScorecardOptions(),
     publicAccess: new ScorecardAccess({
         id: "public",
         type: "public",

--- a/src/media-queries.css
+++ b/src/media-queries.css
@@ -45,8 +45,24 @@
     display: -ms-flexbox;
     display: flex;
     -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
 }
+
+.data-configuration-row {
+    display: flex;
+    gap: 16px;
+    align-items: start;
+    height: 100%;
+    width: 100%;
+    justify-content: center;
+}
+
+@media (max-width: 1700px) {
+    .data-configuration-row {
+        flex-direction: column;
+        width: 100%;
+    }
+}
+
 
 .no-gutters {
     margin-right: 0;
@@ -284,165 +300,205 @@
         flex-grow: 1;
         max-width: 100%;
     }
+
     .col-sm-auto {
         -ms-flex: 0 0 auto;
         flex: 0 0 auto;
         width: auto;
         max-width: none;
     }
+
     .col-sm-1 {
         -ms-flex: 0 0 8.333333%;
         flex: 0 0 8.333333%;
         max-width: 8.333333%;
     }
+
     .col-sm-2 {
         -ms-flex: 0 0 16.666667%;
         flex: 0 0 16.666667%;
         max-width: 16.666667%;
     }
+
     .col-sm-3 {
         -ms-flex: 0 0 25%;
         flex: 0 0 25%;
         max-width: 25%;
     }
+
     .col-sm-4 {
         -ms-flex: 0 0 33.333333%;
         flex: 0 0 33.333333%;
         max-width: 33.333333%;
     }
+
     .col-sm-5 {
         -ms-flex: 0 0 41.666667%;
         flex: 0 0 41.666667%;
         max-width: 41.666667%;
     }
+
     .col-sm-6 {
         -ms-flex: 0 0 50%;
         flex: 0 0 50%;
         max-width: 50%;
     }
+
     .col-sm-7 {
         -ms-flex: 0 0 58.333333%;
         flex: 0 0 58.333333%;
         max-width: 58.333333%;
     }
+
     .col-sm-8 {
         -ms-flex: 0 0 66.666667%;
         flex: 0 0 66.666667%;
         max-width: 66.666667%;
     }
+
     .col-sm-9 {
         -ms-flex: 0 0 75%;
         flex: 0 0 75%;
         max-width: 75%;
     }
+
     .col-sm-10 {
         -ms-flex: 0 0 83.333333%;
         flex: 0 0 83.333333%;
         max-width: 83.333333%;
     }
+
     .col-sm-11 {
         -ms-flex: 0 0 91.666667%;
         flex: 0 0 91.666667%;
         max-width: 91.666667%;
     }
+
     .col-sm-12 {
         -ms-flex: 0 0 100%;
         flex: 0 0 100%;
         max-width: 100%;
     }
+
     .order-sm-first {
         -ms-flex-order: -1;
         order: -1;
     }
+
     .order-sm-last {
         -ms-flex-order: 13;
         order: 13;
     }
+
     .order-sm-0 {
         -ms-flex-order: 0;
         order: 0;
     }
+
     .order-sm-1 {
         -ms-flex-order: 1;
         order: 1;
     }
+
     .order-sm-2 {
         -ms-flex-order: 2;
         order: 2;
     }
+
     .order-sm-3 {
         -ms-flex-order: 3;
         order: 3;
     }
+
     .order-sm-4 {
         -ms-flex-order: 4;
         order: 4;
     }
+
     .order-sm-5 {
         -ms-flex-order: 5;
         order: 5;
     }
+
     .order-sm-6 {
         -ms-flex-order: 6;
         order: 6;
     }
+
     .order-sm-7 {
         -ms-flex-order: 7;
         order: 7;
     }
+
     .order-sm-8 {
         -ms-flex-order: 8;
         order: 8;
     }
+
     .order-sm-9 {
         -ms-flex-order: 9;
         order: 9;
     }
+
     .order-sm-10 {
         -ms-flex-order: 10;
         order: 10;
     }
+
     .order-sm-11 {
         -ms-flex-order: 11;
         order: 11;
     }
+
     .order-sm-12 {
         -ms-flex-order: 12;
         order: 12;
     }
+
     .offset-sm-0 {
         margin-left: 0;
     }
+
     .offset-sm-1 {
         margin-left: 8.333333%;
     }
+
     .offset-sm-2 {
         margin-left: 16.666667%;
     }
+
     .offset-sm-3 {
         margin-left: 25%;
     }
+
     .offset-sm-4 {
         margin-left: 33.333333%;
     }
+
     .offset-sm-5 {
         margin-left: 41.666667%;
     }
+
     .offset-sm-6 {
         margin-left: 50%;
     }
+
     .offset-sm-7 {
         margin-left: 58.333333%;
     }
+
     .offset-sm-8 {
         margin-left: 66.666667%;
     }
+
     .offset-sm-9 {
         margin-left: 75%;
     }
+
     .offset-sm-10 {
         margin-left: 83.333333%;
     }
+
     .offset-sm-11 {
         margin-left: 91.666667%;
     }
@@ -456,165 +512,205 @@
         flex-grow: 1;
         max-width: 100%;
     }
+
     .col-md-auto {
         -ms-flex: 0 0 auto;
         flex: 0 0 auto;
         width: auto;
         max-width: none;
     }
+
     .col-md-1 {
         -ms-flex: 0 0 8.333333%;
         flex: 0 0 8.333333%;
         max-width: 8.333333%;
     }
+
     .col-md-2 {
         -ms-flex: 0 0 16.666667%;
         flex: 0 0 16.666667%;
         max-width: 16.666667%;
     }
+
     .col-md-3 {
         -ms-flex: 0 0 25%;
         flex: 0 0 25%;
         max-width: 25%;
     }
+
     .col-md-4 {
         -ms-flex: 0 0 33.333333%;
         flex: 0 0 33.333333%;
         max-width: 33.333333%;
     }
+
     .col-md-5 {
         -ms-flex: 0 0 41.666667%;
         flex: 0 0 41.666667%;
         max-width: 41.666667%;
     }
+
     .col-md-6 {
         -ms-flex: 0 0 50%;
         flex: 0 0 50%;
         max-width: 50%;
     }
+
     .col-md-7 {
         -ms-flex: 0 0 58.333333%;
         flex: 0 0 58.333333%;
         max-width: 58.333333%;
     }
+
     .col-md-8 {
         -ms-flex: 0 0 66.666667%;
         flex: 0 0 66.666667%;
         max-width: 66.666667%;
     }
+
     .col-md-9 {
         -ms-flex: 0 0 75%;
         flex: 0 0 75%;
         max-width: 75%;
     }
+
     .col-md-10 {
         -ms-flex: 0 0 83.333333%;
         flex: 0 0 83.333333%;
         max-width: 83.333333%;
     }
+
     .col-md-11 {
         -ms-flex: 0 0 91.666667%;
         flex: 0 0 91.666667%;
         max-width: 91.666667%;
     }
+
     .col-md-12 {
         -ms-flex: 0 0 100%;
         flex: 0 0 100%;
         max-width: 100%;
     }
+
     .order-md-first {
         -ms-flex-order: -1;
         order: -1;
     }
+
     .order-md-last {
         -ms-flex-order: 13;
         order: 13;
     }
+
     .order-md-0 {
         -ms-flex-order: 0;
         order: 0;
     }
+
     .order-md-1 {
         -ms-flex-order: 1;
         order: 1;
     }
+
     .order-md-2 {
         -ms-flex-order: 2;
         order: 2;
     }
+
     .order-md-3 {
         -ms-flex-order: 3;
         order: 3;
     }
+
     .order-md-4 {
         -ms-flex-order: 4;
         order: 4;
     }
+
     .order-md-5 {
         -ms-flex-order: 5;
         order: 5;
     }
+
     .order-md-6 {
         -ms-flex-order: 6;
         order: 6;
     }
+
     .order-md-7 {
         -ms-flex-order: 7;
         order: 7;
     }
+
     .order-md-8 {
         -ms-flex-order: 8;
         order: 8;
     }
+
     .order-md-9 {
         -ms-flex-order: 9;
         order: 9;
     }
+
     .order-md-10 {
         -ms-flex-order: 10;
         order: 10;
     }
+
     .order-md-11 {
         -ms-flex-order: 11;
         order: 11;
     }
+
     .order-md-12 {
         -ms-flex-order: 12;
         order: 12;
     }
+
     .offset-md-0 {
         margin-left: 0;
     }
+
     .offset-md-1 {
         margin-left: 8.333333%;
     }
+
     .offset-md-2 {
         margin-left: 16.666667%;
     }
+
     .offset-md-3 {
         margin-left: 25%;
     }
+
     .offset-md-4 {
         margin-left: 33.333333%;
     }
+
     .offset-md-5 {
         margin-left: 41.666667%;
     }
+
     .offset-md-6 {
         margin-left: 50%;
     }
+
     .offset-md-7 {
         margin-left: 58.333333%;
     }
+
     .offset-md-8 {
         margin-left: 66.666667%;
     }
+
     .offset-md-9 {
         margin-left: 75%;
     }
+
     .offset-md-10 {
         margin-left: 83.333333%;
     }
+
     .offset-md-11 {
         margin-left: 91.666667%;
     }
@@ -628,165 +724,205 @@
         flex-grow: 1;
         max-width: 100%;
     }
+
     .col-lg-auto {
         -ms-flex: 0 0 auto;
         flex: 0 0 auto;
         width: auto;
         max-width: none;
     }
+
     .col-lg-1 {
         -ms-flex: 0 0 8.333333%;
         flex: 0 0 8.333333%;
         max-width: 8.333333%;
     }
+
     .col-lg-2 {
         -ms-flex: 0 0 16.666667%;
         flex: 0 0 16.666667%;
         max-width: 16.666667%;
     }
+
     .col-lg-3 {
         -ms-flex: 0 0 25%;
         flex: 0 0 25%;
         max-width: 25%;
     }
+
     .col-lg-4 {
         -ms-flex: 0 0 33.333333%;
         flex: 0 0 33.333333%;
         max-width: 33.333333%;
     }
+
     .col-lg-5 {
         -ms-flex: 0 0 41.666667%;
         flex: 0 0 41.666667%;
         max-width: 41.666667%;
     }
+
     .col-lg-6 {
         -ms-flex: 0 0 50%;
         flex: 0 0 50%;
         max-width: 50%;
     }
+
     .col-lg-7 {
         -ms-flex: 0 0 58.333333%;
         flex: 0 0 58.333333%;
         max-width: 58.333333%;
     }
+
     .col-lg-8 {
         -ms-flex: 0 0 66.666667%;
         flex: 0 0 66.666667%;
         max-width: 66.666667%;
     }
+
     .col-lg-9 {
         -ms-flex: 0 0 75%;
         flex: 0 0 75%;
         max-width: 75%;
     }
+
     .col-lg-10 {
         -ms-flex: 0 0 83.333333%;
         flex: 0 0 83.333333%;
         max-width: 83.333333%;
     }
+
     .col-lg-11 {
         -ms-flex: 0 0 91.666667%;
         flex: 0 0 91.666667%;
         max-width: 91.666667%;
     }
+
     .col-lg-12 {
         -ms-flex: 0 0 100%;
         flex: 0 0 100%;
         max-width: 100%;
     }
+
     .order-lg-first {
         -ms-flex-order: -1;
         order: -1;
     }
+
     .order-lg-last {
         -ms-flex-order: 13;
         order: 13;
     }
+
     .order-lg-0 {
         -ms-flex-order: 0;
         order: 0;
     }
+
     .order-lg-1 {
         -ms-flex-order: 1;
         order: 1;
     }
+
     .order-lg-2 {
         -ms-flex-order: 2;
         order: 2;
     }
+
     .order-lg-3 {
         -ms-flex-order: 3;
         order: 3;
     }
+
     .order-lg-4 {
         -ms-flex-order: 4;
         order: 4;
     }
+
     .order-lg-5 {
         -ms-flex-order: 5;
         order: 5;
     }
+
     .order-lg-6 {
         -ms-flex-order: 6;
         order: 6;
     }
+
     .order-lg-7 {
         -ms-flex-order: 7;
         order: 7;
     }
+
     .order-lg-8 {
         -ms-flex-order: 8;
         order: 8;
     }
+
     .order-lg-9 {
         -ms-flex-order: 9;
         order: 9;
     }
+
     .order-lg-10 {
         -ms-flex-order: 10;
         order: 10;
     }
+
     .order-lg-11 {
         -ms-flex-order: 11;
         order: 11;
     }
+
     .order-lg-12 {
         -ms-flex-order: 12;
         order: 12;
     }
+
     .offset-lg-0 {
         margin-left: 0;
     }
+
     .offset-lg-1 {
         margin-left: 8.333333%;
     }
+
     .offset-lg-2 {
         margin-left: 16.666667%;
     }
+
     .offset-lg-3 {
         margin-left: 25%;
     }
+
     .offset-lg-4 {
         margin-left: 33.333333%;
     }
+
     .offset-lg-5 {
         margin-left: 41.666667%;
     }
+
     .offset-lg-6 {
         margin-left: 50%;
     }
+
     .offset-lg-7 {
         margin-left: 58.333333%;
     }
+
     .offset-lg-8 {
         margin-left: 66.666667%;
     }
+
     .offset-lg-9 {
         margin-left: 75%;
     }
+
     .offset-lg-10 {
         margin-left: 83.333333%;
     }
+
     .offset-lg-11 {
         margin-left: 91.666667%;
     }
@@ -800,165 +936,205 @@
         flex-grow: 1;
         max-width: 100%;
     }
+
     .col-xl-auto {
         -ms-flex: 0 0 auto;
         flex: 0 0 auto;
         width: auto;
         max-width: none;
     }
+
     .col-xl-1 {
         -ms-flex: 0 0 8.333333%;
         flex: 0 0 8.333333%;
         max-width: 8.333333%;
     }
+
     .col-xl-2 {
         -ms-flex: 0 0 16.666667%;
         flex: 0 0 16.666667%;
         max-width: 16.666667%;
     }
+
     .col-xl-3 {
         -ms-flex: 0 0 25%;
         flex: 0 0 25%;
         max-width: 25%;
     }
+
     .col-xl-4 {
         -ms-flex: 0 0 33.333333%;
         flex: 0 0 33.333333%;
         max-width: 33.333333%;
     }
+
     .col-xl-5 {
         -ms-flex: 0 0 41.666667%;
         flex: 0 0 41.666667%;
         max-width: 41.666667%;
     }
+
     .col-xl-6 {
         -ms-flex: 0 0 50%;
         flex: 0 0 50%;
         max-width: 50%;
     }
+
     .col-xl-7 {
         -ms-flex: 0 0 58.333333%;
         flex: 0 0 58.333333%;
         max-width: 58.333333%;
     }
+
     .col-xl-8 {
         -ms-flex: 0 0 66.666667%;
         flex: 0 0 66.666667%;
         max-width: 66.666667%;
     }
+
     .col-xl-9 {
         -ms-flex: 0 0 75%;
         flex: 0 0 75%;
         max-width: 75%;
     }
+
     .col-xl-10 {
         -ms-flex: 0 0 83.333333%;
         flex: 0 0 83.333333%;
         max-width: 83.333333%;
     }
+
     .col-xl-11 {
         -ms-flex: 0 0 91.666667%;
         flex: 0 0 91.666667%;
         max-width: 91.666667%;
     }
+
     .col-xl-12 {
         -ms-flex: 0 0 100%;
         flex: 0 0 100%;
         max-width: 100%;
     }
+
     .order-xl-first {
         -ms-flex-order: -1;
         order: -1;
     }
+
     .order-xl-last {
         -ms-flex-order: 13;
         order: 13;
     }
+
     .order-xl-0 {
         -ms-flex-order: 0;
         order: 0;
     }
+
     .order-xl-1 {
         -ms-flex-order: 1;
         order: 1;
     }
+
     .order-xl-2 {
         -ms-flex-order: 2;
         order: 2;
     }
+
     .order-xl-3 {
         -ms-flex-order: 3;
         order: 3;
     }
+
     .order-xl-4 {
         -ms-flex-order: 4;
         order: 4;
     }
+
     .order-xl-5 {
         -ms-flex-order: 5;
         order: 5;
     }
+
     .order-xl-6 {
         -ms-flex-order: 6;
         order: 6;
     }
+
     .order-xl-7 {
         -ms-flex-order: 7;
         order: 7;
     }
+
     .order-xl-8 {
         -ms-flex-order: 8;
         order: 8;
     }
+
     .order-xl-9 {
         -ms-flex-order: 9;
         order: 9;
     }
+
     .order-xl-10 {
         -ms-flex-order: 10;
         order: 10;
     }
+
     .order-xl-11 {
         -ms-flex-order: 11;
         order: 11;
     }
+
     .order-xl-12 {
         -ms-flex-order: 12;
         order: 12;
     }
+
     .offset-xl-0 {
         margin-left: 0;
     }
+
     .offset-xl-1 {
         margin-left: 8.333333%;
     }
+
     .offset-xl-2 {
         margin-left: 16.666667%;
     }
+
     .offset-xl-3 {
         margin-left: 25%;
     }
+
     .offset-xl-4 {
         margin-left: 33.333333%;
     }
+
     .offset-xl-5 {
         margin-left: 41.666667%;
     }
+
     .offset-xl-6 {
         margin-left: 50%;
     }
+
     .offset-xl-7 {
         margin-left: 58.333333%;
     }
+
     .offset-xl-8 {
         margin-left: 66.666667%;
     }
+
     .offset-xl-9 {
         margin-left: 75%;
     }
+
     .offset-xl-10 {
         margin-left: 83.333333%;
     }
+
     .offset-xl-11 {
         margin-left: 91.666667%;
     }
@@ -1006,28 +1182,36 @@
     .d-sm-none {
         display: none !important;
     }
+
     .d-sm-inline {
         display: inline !important;
     }
+
     .d-sm-inline-block {
         display: inline-block !important;
     }
+
     .d-sm-block {
         display: block !important;
     }
+
     .d-sm-table {
         display: table !important;
     }
+
     .d-sm-table-row {
         display: table-row !important;
     }
+
     .d-sm-table-cell {
         display: table-cell !important;
     }
+
     .d-sm-flex {
         display: -ms-flexbox !important;
         display: flex !important;
     }
+
     .d-sm-inline-flex {
         display: -ms-inline-flexbox !important;
         display: inline-flex !important;
@@ -1038,28 +1222,36 @@
     .d-md-none {
         display: none !important;
     }
+
     .d-md-inline {
         display: inline !important;
     }
+
     .d-md-inline-block {
         display: inline-block !important;
     }
+
     .d-md-block {
         display: block !important;
     }
+
     .d-md-table {
         display: table !important;
     }
+
     .d-md-table-row {
         display: table-row !important;
     }
+
     .d-md-table-cell {
         display: table-cell !important;
     }
+
     .d-md-flex {
         display: -ms-flexbox !important;
         display: flex !important;
     }
+
     .d-md-inline-flex {
         display: -ms-inline-flexbox !important;
         display: inline-flex !important;
@@ -1070,28 +1262,36 @@
     .d-lg-none {
         display: none !important;
     }
+
     .d-lg-inline {
         display: inline !important;
     }
+
     .d-lg-inline-block {
         display: inline-block !important;
     }
+
     .d-lg-block {
         display: block !important;
     }
+
     .d-lg-table {
         display: table !important;
     }
+
     .d-lg-table-row {
         display: table-row !important;
     }
+
     .d-lg-table-cell {
         display: table-cell !important;
     }
+
     .d-lg-flex {
         display: -ms-flexbox !important;
         display: flex !important;
     }
+
     .d-lg-inline-flex {
         display: -ms-inline-flexbox !important;
         display: inline-flex !important;
@@ -1102,28 +1302,36 @@
     .d-xl-none {
         display: none !important;
     }
+
     .d-xl-inline {
         display: inline !important;
     }
+
     .d-xl-inline-block {
         display: inline-block !important;
     }
+
     .d-xl-block {
         display: block !important;
     }
+
     .d-xl-table {
         display: table !important;
     }
+
     .d-xl-table-row {
         display: table-row !important;
     }
+
     .d-xl-table-cell {
         display: table-cell !important;
     }
+
     .d-xl-flex {
         display: -ms-flexbox !important;
         display: flex !important;
     }
+
     .d-xl-inline-flex {
         display: -ms-inline-flexbox !important;
         display: inline-flex !important;
@@ -1134,28 +1342,36 @@
     .d-print-none {
         display: none !important;
     }
+
     .d-print-inline {
         display: inline !important;
     }
+
     .d-print-inline-block {
         display: inline-block !important;
     }
+
     .d-print-block {
         display: block !important;
     }
+
     .d-print-table {
         display: table !important;
     }
+
     .d-print-table-row {
         display: table-row !important;
     }
+
     .d-print-table-cell {
         display: table-cell !important;
     }
+
     .d-print-flex {
         display: -ms-flexbox !important;
         display: flex !important;
     }
+
     .d-print-inline-flex {
         display: -ms-inline-flexbox !important;
         display: inline-flex !important;
@@ -1337,134 +1553,167 @@
         -ms-flex-direction: row !important;
         flex-direction: row !important;
     }
+
     .flex-sm-column {
         -ms-flex-direction: column !important;
         flex-direction: column !important;
     }
+
     .flex-sm-row-reverse {
         -ms-flex-direction: row-reverse !important;
         flex-direction: row-reverse !important;
     }
+
     .flex-sm-column-reverse {
         -ms-flex-direction: column-reverse !important;
         flex-direction: column-reverse !important;
     }
+
     .flex-sm-wrap {
         -ms-flex-wrap: wrap !important;
         flex-wrap: wrap !important;
     }
+
     .flex-sm-nowrap {
         -ms-flex-wrap: nowrap !important;
         flex-wrap: nowrap !important;
     }
+
     .flex-sm-wrap-reverse {
         -ms-flex-wrap: wrap-reverse !important;
         flex-wrap: wrap-reverse !important;
     }
+
     .flex-sm-fill {
         -ms-flex: 1 1 auto !important;
         flex: 1 1 auto !important;
     }
+
     .flex-sm-grow-0 {
         -ms-flex-positive: 0 !important;
         flex-grow: 0 !important;
     }
+
     .flex-sm-grow-1 {
         -ms-flex-positive: 1 !important;
         flex-grow: 1 !important;
     }
+
     .flex-sm-shrink-0 {
         -ms-flex-negative: 0 !important;
         flex-shrink: 0 !important;
     }
+
     .flex-sm-shrink-1 {
         -ms-flex-negative: 1 !important;
         flex-shrink: 1 !important;
     }
+
     .justify-content-sm-start {
         -ms-flex-pack: start !important;
         justify-content: flex-start !important;
     }
+
     .justify-content-sm-end {
         -ms-flex-pack: end !important;
         justify-content: flex-end !important;
     }
+
     .justify-content-sm-center {
         -ms-flex-pack: center !important;
         justify-content: center !important;
     }
+
     .justify-content-sm-between {
         -ms-flex-pack: justify !important;
         justify-content: space-between !important;
     }
+
     .justify-content-sm-around {
         -ms-flex-pack: distribute !important;
         justify-content: space-around !important;
     }
+
     .align-items-sm-start {
         -ms-flex-align: start !important;
         align-items: flex-start !important;
     }
+
     .align-items-sm-end {
         -ms-flex-align: end !important;
         align-items: flex-end !important;
     }
+
     .align-items-sm-center {
         -ms-flex-align: center !important;
         align-items: center !important;
     }
+
     .align-items-sm-baseline {
         -ms-flex-align: baseline !important;
         align-items: baseline !important;
     }
+
     .align-items-sm-stretch {
         -ms-flex-align: stretch !important;
         align-items: stretch !important;
     }
+
     .align-content-sm-start {
         -ms-flex-line-pack: start !important;
         align-content: flex-start !important;
     }
+
     .align-content-sm-end {
         -ms-flex-line-pack: end !important;
         align-content: flex-end !important;
     }
+
     .align-content-sm-center {
         -ms-flex-line-pack: center !important;
         align-content: center !important;
     }
+
     .align-content-sm-between {
         -ms-flex-line-pack: justify !important;
         align-content: space-between !important;
     }
+
     .align-content-sm-around {
         -ms-flex-line-pack: distribute !important;
         align-content: space-around !important;
     }
+
     .align-content-sm-stretch {
         -ms-flex-line-pack: stretch !important;
         align-content: stretch !important;
     }
+
     .align-self-sm-auto {
         -ms-flex-item-align: auto !important;
         align-self: auto !important;
     }
+
     .align-self-sm-start {
         -ms-flex-item-align: start !important;
         align-self: flex-start !important;
     }
+
     .align-self-sm-end {
         -ms-flex-item-align: end !important;
         align-self: flex-end !important;
     }
+
     .align-self-sm-center {
         -ms-flex-item-align: center !important;
         align-self: center !important;
     }
+
     .align-self-sm-baseline {
         -ms-flex-item-align: baseline !important;
         align-self: baseline !important;
     }
+
     .align-self-sm-stretch {
         -ms-flex-item-align: stretch !important;
         align-self: stretch !important;
@@ -1476,134 +1725,167 @@
         -ms-flex-direction: row !important;
         flex-direction: row !important;
     }
+
     .flex-md-column {
         -ms-flex-direction: column !important;
         flex-direction: column !important;
     }
+
     .flex-md-row-reverse {
         -ms-flex-direction: row-reverse !important;
         flex-direction: row-reverse !important;
     }
+
     .flex-md-column-reverse {
         -ms-flex-direction: column-reverse !important;
         flex-direction: column-reverse !important;
     }
+
     .flex-md-wrap {
         -ms-flex-wrap: wrap !important;
         flex-wrap: wrap !important;
     }
+
     .flex-md-nowrap {
         -ms-flex-wrap: nowrap !important;
         flex-wrap: nowrap !important;
     }
+
     .flex-md-wrap-reverse {
         -ms-flex-wrap: wrap-reverse !important;
         flex-wrap: wrap-reverse !important;
     }
+
     .flex-md-fill {
         -ms-flex: 1 1 auto !important;
         flex: 1 1 auto !important;
     }
+
     .flex-md-grow-0 {
         -ms-flex-positive: 0 !important;
         flex-grow: 0 !important;
     }
+
     .flex-md-grow-1 {
         -ms-flex-positive: 1 !important;
         flex-grow: 1 !important;
     }
+
     .flex-md-shrink-0 {
         -ms-flex-negative: 0 !important;
         flex-shrink: 0 !important;
     }
+
     .flex-md-shrink-1 {
         -ms-flex-negative: 1 !important;
         flex-shrink: 1 !important;
     }
+
     .justify-content-md-start {
         -ms-flex-pack: start !important;
         justify-content: flex-start !important;
     }
+
     .justify-content-md-end {
         -ms-flex-pack: end !important;
         justify-content: flex-end !important;
     }
+
     .justify-content-md-center {
         -ms-flex-pack: center !important;
         justify-content: center !important;
     }
+
     .justify-content-md-between {
         -ms-flex-pack: justify !important;
         justify-content: space-between !important;
     }
+
     .justify-content-md-around {
         -ms-flex-pack: distribute !important;
         justify-content: space-around !important;
     }
+
     .align-items-md-start {
         -ms-flex-align: start !important;
         align-items: flex-start !important;
     }
+
     .align-items-md-end {
         -ms-flex-align: end !important;
         align-items: flex-end !important;
     }
+
     .align-items-md-center {
         -ms-flex-align: center !important;
         align-items: center !important;
     }
+
     .align-items-md-baseline {
         -ms-flex-align: baseline !important;
         align-items: baseline !important;
     }
+
     .align-items-md-stretch {
         -ms-flex-align: stretch !important;
         align-items: stretch !important;
     }
+
     .align-content-md-start {
         -ms-flex-line-pack: start !important;
         align-content: flex-start !important;
     }
+
     .align-content-md-end {
         -ms-flex-line-pack: end !important;
         align-content: flex-end !important;
     }
+
     .align-content-md-center {
         -ms-flex-line-pack: center !important;
         align-content: center !important;
     }
+
     .align-content-md-between {
         -ms-flex-line-pack: justify !important;
         align-content: space-between !important;
     }
+
     .align-content-md-around {
         -ms-flex-line-pack: distribute !important;
         align-content: space-around !important;
     }
+
     .align-content-md-stretch {
         -ms-flex-line-pack: stretch !important;
         align-content: stretch !important;
     }
+
     .align-self-md-auto {
         -ms-flex-item-align: auto !important;
         align-self: auto !important;
     }
+
     .align-self-md-start {
         -ms-flex-item-align: start !important;
         align-self: flex-start !important;
     }
+
     .align-self-md-end {
         -ms-flex-item-align: end !important;
         align-self: flex-end !important;
     }
+
     .align-self-md-center {
         -ms-flex-item-align: center !important;
         align-self: center !important;
     }
+
     .align-self-md-baseline {
         -ms-flex-item-align: baseline !important;
         align-self: baseline !important;
     }
+
     .align-self-md-stretch {
         -ms-flex-item-align: stretch !important;
         align-self: stretch !important;
@@ -1615,134 +1897,167 @@
         -ms-flex-direction: row !important;
         flex-direction: row !important;
     }
+
     .flex-lg-column {
         -ms-flex-direction: column !important;
         flex-direction: column !important;
     }
+
     .flex-lg-row-reverse {
         -ms-flex-direction: row-reverse !important;
         flex-direction: row-reverse !important;
     }
+
     .flex-lg-column-reverse {
         -ms-flex-direction: column-reverse !important;
         flex-direction: column-reverse !important;
     }
+
     .flex-lg-wrap {
         -ms-flex-wrap: wrap !important;
         flex-wrap: wrap !important;
     }
+
     .flex-lg-nowrap {
         -ms-flex-wrap: nowrap !important;
         flex-wrap: nowrap !important;
     }
+
     .flex-lg-wrap-reverse {
         -ms-flex-wrap: wrap-reverse !important;
         flex-wrap: wrap-reverse !important;
     }
+
     .flex-lg-fill {
         -ms-flex: 1 1 auto !important;
         flex: 1 1 auto !important;
     }
+
     .flex-lg-grow-0 {
         -ms-flex-positive: 0 !important;
         flex-grow: 0 !important;
     }
+
     .flex-lg-grow-1 {
         -ms-flex-positive: 1 !important;
         flex-grow: 1 !important;
     }
+
     .flex-lg-shrink-0 {
         -ms-flex-negative: 0 !important;
         flex-shrink: 0 !important;
     }
+
     .flex-lg-shrink-1 {
         -ms-flex-negative: 1 !important;
         flex-shrink: 1 !important;
     }
+
     .justify-content-lg-start {
         -ms-flex-pack: start !important;
         justify-content: flex-start !important;
     }
+
     .justify-content-lg-end {
         -ms-flex-pack: end !important;
         justify-content: flex-end !important;
     }
+
     .justify-content-lg-center {
         -ms-flex-pack: center !important;
         justify-content: center !important;
     }
+
     .justify-content-lg-between {
         -ms-flex-pack: justify !important;
         justify-content: space-between !important;
     }
+
     .justify-content-lg-around {
         -ms-flex-pack: distribute !important;
         justify-content: space-around !important;
     }
+
     .align-items-lg-start {
         -ms-flex-align: start !important;
         align-items: flex-start !important;
     }
+
     .align-items-lg-end {
         -ms-flex-align: end !important;
         align-items: flex-end !important;
     }
+
     .align-items-lg-center {
         -ms-flex-align: center !important;
         align-items: center !important;
     }
+
     .align-items-lg-baseline {
         -ms-flex-align: baseline !important;
         align-items: baseline !important;
     }
+
     .align-items-lg-stretch {
         -ms-flex-align: stretch !important;
         align-items: stretch !important;
     }
+
     .align-content-lg-start {
         -ms-flex-line-pack: start !important;
         align-content: flex-start !important;
     }
+
     .align-content-lg-end {
         -ms-flex-line-pack: end !important;
         align-content: flex-end !important;
     }
+
     .align-content-lg-center {
         -ms-flex-line-pack: center !important;
         align-content: center !important;
     }
+
     .align-content-lg-between {
         -ms-flex-line-pack: justify !important;
         align-content: space-between !important;
     }
+
     .align-content-lg-around {
         -ms-flex-line-pack: distribute !important;
         align-content: space-around !important;
     }
+
     .align-content-lg-stretch {
         -ms-flex-line-pack: stretch !important;
         align-content: stretch !important;
     }
+
     .align-self-lg-auto {
         -ms-flex-item-align: auto !important;
         align-self: auto !important;
     }
+
     .align-self-lg-start {
         -ms-flex-item-align: start !important;
         align-self: flex-start !important;
     }
+
     .align-self-lg-end {
         -ms-flex-item-align: end !important;
         align-self: flex-end !important;
     }
+
     .align-self-lg-center {
         -ms-flex-item-align: center !important;
         align-self: center !important;
     }
+
     .align-self-lg-baseline {
         -ms-flex-item-align: baseline !important;
         align-self: baseline !important;
     }
+
     .align-self-lg-stretch {
         -ms-flex-item-align: stretch !important;
         align-self: stretch !important;
@@ -1754,137 +2069,171 @@
         -ms-flex-direction: row !important;
         flex-direction: row !important;
     }
+
     .flex-xl-column {
         -ms-flex-direction: column !important;
         flex-direction: column !important;
     }
+
     .flex-xl-row-reverse {
         -ms-flex-direction: row-reverse !important;
         flex-direction: row-reverse !important;
     }
+
     .flex-xl-column-reverse {
         -ms-flex-direction: column-reverse !important;
         flex-direction: column-reverse !important;
     }
+
     .flex-xl-wrap {
         -ms-flex-wrap: wrap !important;
         flex-wrap: wrap !important;
     }
+
     .flex-xl-nowrap {
         -ms-flex-wrap: nowrap !important;
         flex-wrap: nowrap !important;
     }
+
     .flex-xl-wrap-reverse {
         -ms-flex-wrap: wrap-reverse !important;
         flex-wrap: wrap-reverse !important;
     }
+
     .flex-xl-fill {
         -ms-flex: 1 1 auto !important;
         flex: 1 1 auto !important;
     }
+
     .flex-xl-grow-0 {
         -ms-flex-positive: 0 !important;
         flex-grow: 0 !important;
     }
+
     .flex-xl-grow-1 {
         -ms-flex-positive: 1 !important;
         flex-grow: 1 !important;
     }
+
     .flex-xl-shrink-0 {
         -ms-flex-negative: 0 !important;
         flex-shrink: 0 !important;
     }
+
     .flex-xl-shrink-1 {
         -ms-flex-negative: 1 !important;
         flex-shrink: 1 !important;
     }
+
     .justify-content-xl-start {
         -ms-flex-pack: start !important;
         justify-content: flex-start !important;
     }
+
     .justify-content-xl-end {
         -ms-flex-pack: end !important;
         justify-content: flex-end !important;
     }
+
     .justify-content-xl-center {
         -ms-flex-pack: center !important;
         justify-content: center !important;
     }
+
     .justify-content-xl-between {
         -ms-flex-pack: justify !important;
         justify-content: space-between !important;
     }
+
     .justify-content-xl-around {
         -ms-flex-pack: distribute !important;
         justify-content: space-around !important;
     }
+
     .align-items-xl-start {
         -ms-flex-align: start !important;
         align-items: flex-start !important;
     }
+
     .align-items-xl-end {
         -ms-flex-align: end !important;
         align-items: flex-end !important;
     }
+
     .align-items-xl-center {
         -ms-flex-align: center !important;
         align-items: center !important;
     }
+
     .align-items-xl-baseline {
         -ms-flex-align: baseline !important;
         align-items: baseline !important;
     }
+
     .align-items-xl-stretch {
         -ms-flex-align: stretch !important;
         align-items: stretch !important;
     }
+
     .align-content-xl-start {
         -ms-flex-line-pack: start !important;
         align-content: flex-start !important;
     }
+
     .align-content-xl-end {
         -ms-flex-line-pack: end !important;
         align-content: flex-end !important;
     }
+
     .align-content-xl-center {
         -ms-flex-line-pack: center !important;
         align-content: center !important;
     }
+
     .align-content-xl-between {
         -ms-flex-line-pack: justify !important;
         align-content: space-between !important;
     }
+
     .align-content-xl-around {
         -ms-flex-line-pack: distribute !important;
         align-content: space-around !important;
     }
+
     .align-content-xl-stretch {
         -ms-flex-line-pack: stretch !important;
         align-content: stretch !important;
     }
+
     .align-self-xl-auto {
         -ms-flex-item-align: auto !important;
         align-self: auto !important;
     }
+
     .align-self-xl-start {
         -ms-flex-item-align: start !important;
         align-self: flex-start !important;
     }
+
     .align-self-xl-end {
         -ms-flex-item-align: end !important;
         align-self: flex-end !important;
     }
+
     .align-self-xl-center {
         -ms-flex-item-align: center !important;
         align-self: center !important;
     }
+
     .align-self-xl-baseline {
         -ms-flex-item-align: baseline !important;
         align-self: baseline !important;
     }
+
     .align-self-xl-stretch {
         -ms-flex-item-align: stretch !important;
         align-self: stretch !important;
     }
 }
+
 /*# sourceMappingURL=bootstrap-grid.css.map */

--- a/src/modules/Main/Components/ScoreCardManagement/Components/DataConfiguration/Components/DataGroups/Components/DataSourceConfiguration/Components/Form/index.js
+++ b/src/modules/Main/Components/ScoreCardManagement/Components/DataConfiguration/Components/DataGroups/Components/DataSourceConfiguration/Components/Form/index.js
@@ -22,17 +22,16 @@ export default function SelectedDataSourceConfigurationForm() {
     const selectedDataHolder = watch(path);
 
     return (
-        <div className="row-media">
+        <div className="data-configuration-row">
             {selectedDataHolder?.dataSources?.map((dataSource, index) => {
-
                 const dataSourcePath = `${path}.dataSources.${index}`;
                 return (
                     <div
                         key={dataSource.id}
-                        className="col-lg-6 col-md-6"
-                        style={{height: "100%"}}
+                        style={{maxWidth: 720, minWidth: 480}}
+                        className="w-100 h-100"
                     >
-                        <div className="container-bordered">
+                        <div className="container-bordered h-100">
                             <div className="column">
                                 <div className="p-16">
                                     <Suspense

--- a/src/modules/Main/Components/ScoreCardManagement/Components/DataConfiguration/Components/DataGroups/Components/DataSourceConfiguration/Components/TargetsArea/index.js
+++ b/src/modules/Main/Components/ScoreCardManagement/Components/DataConfiguration/Components/DataGroups/Components/DataSourceConfiguration/Components/TargetsArea/index.js
@@ -3,7 +3,7 @@ import {CircularLoader, SingleSelectField, SingleSelectOption} from '@dhis2/ui'
 import {RHFCustomInput} from "@hisptz/react-ui";
 import {head, isEmpty} from "lodash";
 import PropTypes from 'prop-types'
-import React, {useEffect, useState, Suspense} from "react";
+import React, {Suspense, useEffect, useState} from "react";
 import {useFormContext} from "react-hook-form";
 import TargetsField
     from "../../../../../../../../../../../../shared/Components/CustomForm/components/DataSourceConfigurationForm/Components/TargetsField";
@@ -16,11 +16,11 @@ import OrgUnitSpecificTargetsModal from "../OrgUnitSpecificTargetsModal";
 import PeriodSpecificTargetsModal from "../PeriodSpecificTargetsModal";
 import {OrgUnitSpecificTargetView, PeriodSpecificTargetView} from "./components/SpecificTargetView";
 
-function getSelectedType(specificTargets, specificTargetSet) {
-    if (!isEmpty(specificTargets) && specificTargetSet) {
+function getSelectedType(specificTargets, specificTargetsSet) {
+    if (!isEmpty(specificTargets) && specificTargetsSet) {
         return head(specificTargets)?.type;
     }
-    if (specificTargetSet) {
+    if (specificTargetsSet) {
         return "orgUnitLevel";
     }
     return null;
@@ -38,13 +38,17 @@ export default function TargetsArea({path}) {
 
     const [selectedType, setSelectedType] = useState(getSelectedType(specificTargets, areSpecificTargetsSet));
 
+    useEffect(() => {
+        if (!areSpecificTargetsSet && !isEmpty(specificTargets)) {
+            setValue(`${path}.specificTargets`, []);
+        }
+    }, [areSpecificTargetsSet, specificTargets, setValue, path]);
 
     useEffect(() => {
         if (selectedType && isEmpty(specificTargets[0]?.items)) {
             setOpenConfigDialog(true);
         }
     }, [selectedType, specificTargets]);
-
 
     return <div className="column gap-16">
         <RHFCustomInput
@@ -77,7 +81,8 @@ export default function TargetsArea({path}) {
                         <SingleSelectOption value="orgUnitLevel" label={i18n.t("Organisation Unit Level")}/>
                     </SingleSelectField>
                     <div className="column gap-8">
-                        <Suspense fallback={ <div className="column align-items-center justify-content-center" style={{ height: 100, width: "100%",}}><CircularLoader small/></div> }>
+                        <Suspense fallback={<div className="column align-items-center justify-content-center"
+                                                 style={{height: 100, width: "100%",}}><CircularLoader small/></div>}>
                             {
                                 selectedType !== "orgUnitLevel" && specificTargets?.map(target => (
                                     selectedType === "period" ?

--- a/src/modules/Main/Components/ScoreCardManagement/Components/DataConfiguration/Components/DataGroups/Components/DataSourceConfiguration/Components/TargetsArea/index.js
+++ b/src/modules/Main/Components/ScoreCardManagement/Components/DataConfiguration/Components/DataGroups/Components/DataSourceConfiguration/Components/TargetsArea/index.js
@@ -40,6 +40,7 @@ export default function TargetsArea({path}) {
 
     useEffect(() => {
         if (!areSpecificTargetsSet && !isEmpty(specificTargets)) {
+            setSelectedType(null);
             setValue(`${path}.specificTargets`, []);
         }
     }, [areSpecificTargetsSet, specificTargets, setValue, path]);

--- a/src/modules/Main/Components/ScoreCardManagement/Components/DataConfiguration/hooks/useDataGroupLayout.js
+++ b/src/modules/Main/Components/ScoreCardManagement/Components/DataConfiguration/hooks/useDataGroupLayout.js
@@ -1,4 +1,4 @@
-import {cloneDeep, find, findIndex, head, last} from "lodash";
+import {cloneDeep, find, findIndex, head, last, set} from "lodash";
 import {useCallback, useMemo} from "react";
 import {useFormContext} from "react-hook-form";
 import {useRecoilCallback} from "recoil";
@@ -53,7 +53,7 @@ export default function useDataGroupLayout({handleAccordionChange, index}) {
             dataHolderToModify?.dataSources?.splice(0, 1)
         );
         const updatedHolderList = [...dataHolders];
-        updatedHolderList.splice(dataHolderIndex, 1, modifiedDataHolder);
+        set(updatedHolderList, [dataHolderIndex], modifiedDataHolder);
         updatedHolderList.splice(dataHolderIndex, 0, newDataHolder);
         setGroup(
             ScorecardIndicatorGroup.set(group, "dataHolders", updatedHolderList)
@@ -85,7 +85,6 @@ export default function useDataGroupLayout({handleAccordionChange, index}) {
     const onExpand = (event, newExpanded) => {
         handleAccordionChange(id)(event, newExpanded);
     };
-
 
     return {
         onLink,

--- a/src/modules/Main/Components/ScoreCardManagement/Components/Options/hooks/useOptionsManage.js
+++ b/src/modules/Main/Components/ScoreCardManagement/Components/Options/hooks/useOptionsManage.js
@@ -6,11 +6,11 @@ import ScorecardOptions from "../../../../../../../core/models/scorecardOptions"
 export default function useOptionsManage(){
     const {watch, setValue} = useFormContext();
 
-    const scorecardOptions = watch("scorecardOptions");
+    const scorecardOptions = watch("options");
 
     const setScorecardOptions = useCallback(
         (updatedOptions) => {
-            setValue("scorecardOptions", updatedOptions);
+            setValue("options", updatedOptions);
         },
         [setValue],
     );

--- a/src/shared/Components/CustomForm/components/DataSourceConfigurationForm/index.js
+++ b/src/shared/Components/CustomForm/components/DataSourceConfigurationForm/index.js
@@ -9,13 +9,13 @@ import TargetsArea
 import {DHIS2ValueTypes} from "../../constants";
 
 export default function DataSourceConfigurationForm({path}) {
-    const {getValues, setValue} = useFormContext();
+    const {watch, setValue} = useFormContext();
 
     useEffect(() => {
         if (path) {
-            setValue(path, getValues(path))
+            setValue(path, watch(path))
         }
-    }, [getValues, path, setValue]);
+    }, [watch, path, setValue]);
 
     return (
         <div className="container p-16 data-source-form-container">


### PR DESCRIPTION
 - Unset selected indicator when unlinking indicators
 -  Updated unlink function to use set for updating data holders in the list
 - Fixed issues with duplicate specificTargetsKey being incorrectly written
- Implemented resetting of specificTargets to empty array when specific targets checkbox is unchecked
- Changed default scorecard options key to options instead of scorecardOptions

BREAKING CHANGE: - Change in options field may cause some inconsistencies in some scenarios, reconfiguration of options is advised

Fixes #540 