### PR TITLE
Bugfix: Delete button opens scorecard and pops delete modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ apps/widget/scorecard_widget.zip
 /shared/constants/src/locales/
 /shared/state/src/locales/
 /shared/utils/src/locales/
+/apps/app/cypress/downloads/

--- a/.idea/git_toolbox_prj.xml
+++ b/.idea/git_toolbox_prj.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxProjectSettings">
+    <option name="commitMessageIssueKeyValidationOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+    <option name="commitMessageValidationEnabledOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
+  </component>
+</project>

--- a/apps/app/cypress.json
+++ b/apps/app/cypress.json
@@ -21,8 +21,8 @@
   "env": {
     "dhis2DataTestPrefix": "dhis2-hisptzscorecard",
     "networkMode": "live",
-    "dhis2ApiVersion": "37",
-    "apiVersion": "37"
+    "dhis2ApiVersion": "38",
+    "apiVersion": "38"
   },
   "experimentalInteractiveRunEvents": true,
   "waitForAnimations": true

--- a/apps/app/cypress/integration/0.7-Delete-Scorecard/delete-scorecard.js
+++ b/apps/app/cypress/integration/0.7-Delete-Scorecard/delete-scorecard.js
@@ -3,8 +3,8 @@ When(/^deleting scorecard$/, function () {
     cy.get('[data-test="scorecard-delete-button"]').first().click();
 });
 When(/^confirming to delete scorecard$/, function () {
-    cy.get('[data-test=delete-confirm-modal]').should('be.visible')
-    cy.get('button[data-test=delete-confirm-button]').click()
+    cy.get('[data-test="dhis2-uicore-card"]').should('be.visible')
+    cy.get('button[data-test="dhis2-uicore-button"]').contains("Confirm").click();
 
 });
 Then(/^the deleted scorecard should not be on the list$/, function () {

--- a/apps/app/src/modules/Main/Components/ScorecardList/Components/Cards/ScorecardListCard.js
+++ b/apps/app/src/modules/Main/Components/ScorecardList/Components/Cards/ScorecardListCard.js
@@ -57,7 +57,8 @@ export default function ScorecardListCard({scorecard, grid}) {
         }
     };
 
-    const onDelete = () => {
+    const onDelete = (value, event) => {
+        event.stopPropagation();
         confirm({
             title: i18n.t("Confirm scorecard delete"),
             message: <p>

--- a/apps/app/src/modules/Main/Components/ScorecardList/Components/GridScorecardDisplay.js
+++ b/apps/app/src/modules/Main/Components/ScorecardList/Components/GridScorecardDisplay.js
@@ -5,7 +5,6 @@ import ScorecardListCard from "./Cards/ScorecardListCard";
 export default function GridScorecardDisplay({ scorecards }) {
   return (
     <div
-      data-test="scorecard-card-view"
       className="scorecard-list-container grid p-32"
     >
       {scorecards?.map((scorecard) => (

--- a/apps/app/src/modules/Main/Components/ScorecardList/Components/ListScorecardDisplay.js
+++ b/apps/app/src/modules/Main/Components/ScorecardList/Components/ListScorecardDisplay.js
@@ -4,7 +4,7 @@ import ScorecardListCard from "./Cards/ScorecardListCard";
 
 export default function ListScorecardDisplay({scorecards}) {
     return (
-        <div data-test="scorecard-thumbnail-view" className="column">
+        <div className="column">
             {scorecards?.map((scorecard) => (
                 <ScorecardListCard scorecard={scorecard} key={scorecard?.id} grid={false}/>
             ))}


### PR DESCRIPTION
 - Fixed issues with when clicking on the delete button on the scorecard list, it opens the scorecard view and then pops the delete confirmation. This causes an error when a user deletes the scorecard
 - Fixed test references to delete the modal component

Fixes #657 